### PR TITLE
Generic configuration for sponsorship

### DIFF
--- a/release template/.github/FUNDING.yml
+++ b/release template/.github/FUNDING.yml
@@ -1,0 +1,13 @@
+# These are supported funding model platforms
+
+github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
+patreon: # Replace with a single Patreon username
+open_collective: # Replace with a single Open Collective username
+ko_fi: # Replace with a single Ko-fi username
+tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
+community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
+liberapay: # Replace with a single Liberapay username
+issuehunt: # Replace with a single IssueHunt username
+otechie: # Replace with a single Otechie username
+lfx_crowdfunding: # Replace with a single LFX Crowdfunding project-name e.g., cloud-foundry
+custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']

--- a/release template/.github/FUNDING.yml
+++ b/release template/.github/FUNDING.yml
@@ -1,4 +1,5 @@
 # These are supported funding model platforms
+# Check out the documentation for more details at https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository#displaying-a-sponsor-button-in-your-repository
 
 github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
 patreon: # Replace with a single Patreon username


### PR DESCRIPTION
Hey folks!

Another thing most open source projects have in common is getting funding through sponsorship. Here is a default `FUNDING.yml` template (intentionally authorless) placed in the `.github` subdirectory. I suppose we might want to expand this folder with some good examples of `ISSUE_TEMPLATES` in the future.

Thank you for being the hub of the best in the open source world. ♥️