### PR TITLE
Update to reflect current marketplace url for GHAS compliance tool

### DIFF
--- a/docs/ospo-tools-and-external-guides.md
+++ b/docs/ospo-tools-and-external-guides.md
@@ -12,7 +12,7 @@ These are tools published by employees that can be used by OSPOs for managing op
 
 - [License compliance - A Ruby Gem to detect under what license a project is distributed](https://github.com/licensee/licensee)
 - [Licensed: A Ruby gem to cache and verify the licenses of dependencies](https://github.com/github/licensed)
-- [GitHub Action: Allow users to configure their risk threshold for security issues reported by GitHub Code Scanning, Secret Scanning and Dependabot Security.](https://github.com/marketplace/actions/ghas-policy-as-code) 
+- [GitHub Action: Allow users to configure their risk threshold for security issues reported by GitHub Code Scanning, Secret Scanning and Dependabot Security.](https://github.com/marketplace/actions/ghas-policy-as-code)
 - [Safe Settings - an app to manage policy-as-code and apply repository settings to repositories across an organization.](https://github.com/github/safe-settings)
 
 ### User administration

--- a/docs/ospo-tools-and-external-guides.md
+++ b/docs/ospo-tools-and-external-guides.md
@@ -12,7 +12,7 @@ These are tools published by employees that can be used by OSPOs for managing op
 
 - [License compliance - A Ruby Gem to detect under what license a project is distributed](https://github.com/licensee/licensee)
 - [Licensed: A Ruby gem to cache and verify the licenses of dependencies](https://github.com/github/licensed)
-- [GitHub Action: Allow users to configure their risk threshold for security issues reported by GitHub Code Scanning, Secret Scanning and Dependabot Security.](https://github.com/marketplace/actions/ghascompliance)
+- [GitHub Action: Allow users to configure their risk threshold for security issues reported by GitHub Code Scanning, Secret Scanning and Dependabot Security.](https://github.com/marketplace/actions/ghas-policy-as-code) 
 - [Safe Settings - an app to manage policy-as-code and apply repository settings to repositories across an organization.](https://github.com/github/safe-settings)
 
 ### User administration


### PR DESCRIPTION
Update to reflect current marketplace url for GHAS compliance tool

Current:
![image](https://user-images.githubusercontent.com/22166060/226851125-f9fc0207-a422-41a0-aa16-c67f29639a6d.png)

Updated:
![image](https://user-images.githubusercontent.com/22166060/226851302-1b9b163c-adda-4f2f-853a-4c9f395b76be.png)
