### PR TITLE
Fix broken link in org-presence-on-github.md

### DIFF
--- a/docs/org-presence-on-github.md
+++ b/docs/org-presence-on-github.md
@@ -4,7 +4,7 @@
 
 ### Organization creation
 
-If you already have an organization account, you can skip this section. You should make sure that you are signed in to GitHub and then navigate to [https://github.com/organzations/plan](https://github.com/organzations/plan).
+If you already have an organization account, you can skip this section. You should make sure that you are signed in to GitHub and then navigate to [https://github.com/organizations/plan](https://github.com/organizations/plan).
 
 ![Set up organization](/images/org-setup.png)
 


### PR DESCRIPTION
In file `docs/org-presence-on-github.md` the link <https://github.com/organzations/plan> is broken (has a typo).
I fixed it to <https://github.com/organizations/plan>.