### PR TITLE
Thank contributors monthly via discussions

### DIFF
--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -1,0 +1,49 @@
+name: Monthly contributor reports
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '3 2 1 * *'
+
+permissions:
+  issues: write
+
+jobs:
+  contributor_report:
+    name: contributor reports
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - name: Get dates for last month
+      shell: bash
+      run: |
+        # Calculate the first day of the previous month
+        start_date=$(date -d "last month" +%Y-%m-01)
+
+        # Calculate the last day of the previous month
+        end_date=$(date -d "$start_date +1 month -1 day" +%Y-%m-%d)
+
+        #Set an environment variable with the date range
+        echo "START_DATE=$start_date" >> "$GITHUB_ENV"
+        echo "END_DATE=$end_date" >> "$GITHUB_ENV"
+
+    - name: Run contributor action
+      uses: github/contributors@v1
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        START_DATE: ${{ env.START_DATE }}
+        END_DATE: ${{ env.END_DATE }}
+        REPOSITORY: "github/go-spdx,github-community-projects/internal-contribution-forks,github/stale-repos,github/evergreen,github/issue-metrics,github/github-ospo,github/contributors,github/automatic-contrib-prs,github/cleanowners"
+        SPONSOR_INFO: "true"
+        LINK_TO_PROFILE: "true"
+
+    - name: Create GitHub Discussion
+      uses: abirismyname/create-discussion@v1.2.0
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}  
+      with:
+        title: Thank you Contributors!
+        body-filepath: ./contributors.md
+        repository-id: R_kgDOJDwwMQ
+        category-id: DIC_kwDOJDwwMc4CUmf8
+            

--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -2,7 +2,7 @@ name: Monthly contributor reports
 on:
   workflow_dispatch:
   schedule:
-    - cron: '3 2 1 * *'
+    - cron: "3 2 1 * *"
 
 permissions:
   issues: write
@@ -13,37 +13,35 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Get dates for last month
+        shell: bash
+        run: |
+          # Calculate the first day of the previous month
+          start_date=$(date -d "last month" +%Y-%m-01)
 
-    - name: Get dates for last month
-      shell: bash
-      run: |
-        # Calculate the first day of the previous month
-        start_date=$(date -d "last month" +%Y-%m-01)
+          # Calculate the last day of the previous month
+          end_date=$(date -d "$start_date +1 month -1 day" +%Y-%m-%d)
 
-        # Calculate the last day of the previous month
-        end_date=$(date -d "$start_date +1 month -1 day" +%Y-%m-%d)
+          #Set an environment variable with the date range
+          echo "START_DATE=$start_date" >> "$GITHUB_ENV"
+          echo "END_DATE=$end_date" >> "$GITHUB_ENV"
 
-        #Set an environment variable with the date range
-        echo "START_DATE=$start_date" >> "$GITHUB_ENV"
-        echo "END_DATE=$end_date" >> "$GITHUB_ENV"
+      - name: Run contributor action
+        uses: github/contributors@v1
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          START_DATE: ${{ env.START_DATE }}
+          END_DATE: ${{ env.END_DATE }}
+          REPOSITORY: "github/go-spdx,github-community-projects/internal-contribution-forks,github/stale-repos,github/evergreen,github/issue-metrics,github/github-ospo,github/contributors,github/automatic-contrib-prs,github/cleanowners"
+          SPONSOR_INFO: "true"
+          LINK_TO_PROFILE: "true"
 
-    - name: Run contributor action
-      uses: github/contributors@v1
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        START_DATE: ${{ env.START_DATE }}
-        END_DATE: ${{ env.END_DATE }}
-        REPOSITORY: "github/go-spdx,github-community-projects/internal-contribution-forks,github/stale-repos,github/evergreen,github/issue-metrics,github/github-ospo,github/contributors,github/automatic-contrib-prs,github/cleanowners"
-        SPONSOR_INFO: "true"
-        LINK_TO_PROFILE: "true"
-
-    - name: Create GitHub Discussion
-      uses: abirismyname/create-discussion@v1.2.0
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}  
-      with:
-        title: Thank you Contributors!
-        body-filepath: ./contributors.md
-        repository-id: R_kgDOJDwwMQ
-        category-id: DIC_kwDOJDwwMc4CUmf8
-            
+      - name: Create GitHub Discussion
+        uses: abirismyname/create-discussion@v1.2.0
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          title: Thank you Contributors!
+          body-filepath: ./contributors.md
+          repository-id: R_kgDOJDwwMQ
+          category-id: DIC_kwDOJDwwMc4CUmf8


### PR DESCRIPTION
This pull request introduces a new GitHub workflow named `Monthly contributor reports`. This workflow is set to run on the first day of every month and generates a report of all contributors from the previous month. The report includes contributions to several repositories related to this one and is posted as a GitHub Discussion on this repo.

cc/ @ashleywolf 