### PR TITLE
Removed reference to OSPO newsletter page

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,6 @@ We have used those as placeholder values where our policies point to internal on
   - [Gaining insights into your contributors](./docs/contributor-insights.md)
   - [Managing dependencies at scale](./docs/managing-dependencies-at-scale.md)
   - [Keeping repository maintainer information accurate](./docs/keeping-ownership-updated.md)
-- Misc
-  - [Internal OSPO newsletters](./newsletter%20template)
 
 ## Tools Created by GitHub OSPO
 


### PR DESCRIPTION
OSPO newsletter link goes to an outdated page with little information (https://github.com/github/github-ospo/tree/main/newsletter%20template). I suggest removing it so folks don't click through it.