### PR TITLE
chore: update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ In addition to the information in this repository, we've also released a number 
 - [github/issue-metrics](https://github.com/github/issue-metrics) - Gather metrics on issues/prs/discussions such as time to first response, count of issues opened, closed, etc.
 - [github/stale-repos](https://github.com/github/stale-repos) - Identify and report on repositories with no activity for configurable amount of time, in order to surface inactive repos to be considered for archival
 - [github/cleanowners](https://github.com/github/cleanowners) - A GitHub Action to suggest removal of non-organization members from CODEOWNERS files
-- [github/automatic-contrib-prs](https://github.com/github/automatic-contrib-prs) - Automatically open a pull request for repositories that have no CONTRIBUTING.md file
+- [github/ospo-reusable-workflows](https://github.com/github/ospo-reusable-workflows] - Centralized Reusable GitHub Actions workflows used by the other Actions above (example: release (image and discussion), auto labelling, etc)
 
 ### GitHub Apps
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ In addition to the information in this repository, we've also released a number 
 - [github/issue-metrics](https://github.com/github/issue-metrics) - Gather metrics on issues/prs/discussions such as time to first response, count of issues opened, closed, etc.
 - [github/stale-repos](https://github.com/github/stale-repos) - Identify and report on repositories with no activity for configurable amount of time, in order to surface inactive repos to be considered for archival
 - [github/cleanowners](https://github.com/github/cleanowners) - A GitHub Action to suggest removal of non-organization members from CODEOWNERS files
-- [github/ospo-reusable-workflows](https://github.com/github/ospo-reusable-workflows] - Centralized Reusable GitHub Actions workflows used by the other Actions above (example: release (image and discussion), auto labelling, etc)
+- [github/ospo-reusable-workflows](https://github.com/github/ospo-reusable-workflows) - Centralized Reusable GitHub Actions workflows used by the other Actions above (example: release (image and discussion), auto labelling, etc)
 
 ### GitHub Apps
 


### PR DESCRIPTION
Add github/ospo-reusable-workflows to github ospo tools section and remove github/automatic-contrib-prs as it has been archived.