### PR TITLE
docs: Add empty-repos GitHub app to list

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ In addition to the information in this repository, we've also released a number 
 - [github/issue-metrics](https://github.com/github/issue-metrics) - Gather metrics on issues/prs/discussions such as time to first response, count of issues opened, closed, etc.
 - [github/stale-repos](https://github.com/github/stale-repos) - Identify and report on repositories with no activity for configurable amount of time, in order to surface inactive repos to be considered for archival
 - [github/cleanowners](https://github.com/github/cleanowners) - A GitHub Action to suggest removal of non-organization members from CODEOWNERS files
-- [github/empty-repos](https://github.com/github/empty-repos) - Identify and report an organizations repositories that are empty or only contain a README
+- [github/empty-repos](https://github.com/github/empty-repos) - Identify and report an organization's repositories that are empty or only contain a README
 - [github/ospo-reusable-workflows](https://github.com/github/ospo-reusable-workflows) - Centralized Reusable GitHub Actions workflows used by the other Actions above (example: release (image and discussion), auto labelling, etc)
 
 ### GitHub Apps


### PR DESCRIPTION
This pull request adds a new entry to the list of repositories in the `README.md` file. The new entry highlights the `github/empty-repos` project, which identifies and reports on an organization's repositories that are empty or only contain a README.