### PR TITLE
Update contributors action reference after repo transfer

### DIFF
--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -27,12 +27,12 @@ jobs:
           echo "END_DATE=$end_date" >> "$GITHUB_ENV"
 
       - name: Run contributor action
-        uses: github/contributors@v1
+        uses: github-community-projects/contributors@v2
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           START_DATE: ${{ env.START_DATE }}
           END_DATE: ${{ env.END_DATE }}
-          REPOSITORY: "github/go-spdx,github-community-projects/internal-contribution-forks,github/stale-repos,github/evergreen,github/issue-metrics,github/github-ospo,github/contributors,github/automatic-contrib-prs,github/cleanowners,github/measure-innersource"
+          REPOSITORY: "github/go-spdx,github-community-projects/internal-contribution-forks,github/stale-repos,github/evergreen,github/issue-metrics,github/github-ospo,github-community-projects/contributors,github/automatic-contrib-prs,github/cleanowners,github/measure-innersource"
           SPONSOR_INFO: "true"
           LINK_TO_PROFILE: "true"
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ We have used those as placeholder values where our policies point to internal on
 
 In addition to the information in this repository, we've also released a number of GitHub Actions that can help OSPOs track activity, clean house, and automate other useful activities. The actions are released in separate repos but are all linked here for convenience.
 
-- [github/contributors](https://github.com/github/contributors) - Given an organization or repository, produces information about the contributors over the specified time period.
+- [github-community-projects/contributors](https://github.com/github-community-projects/contributors) - Given an organization or repository, produces information about the contributors over the specified time period.
 - [github/evergreen](https://github.com/github/evergreen) - Enable automated security updates and open a issue/PR in repos in an org that have dependency files but no dependabot.yaml file
 - [github/issue-metrics](https://github.com/github/issue-metrics) - Gather metrics on issues/prs/discussions such as time to first response, count of issues opened, closed, etc.
 - [github/stale-repos](https://github.com/github/stale-repos) - Identify and report on repositories with no activity for configurable amount of time, in order to surface inactive repos to be considered for archival

--- a/docs/contributor-insights.md
+++ b/docs/contributor-insights.md
@@ -35,7 +35,7 @@ Interested in implementing the contributors action in your project or organizati
    Start by creating a new repository to host the contributors GitHub action or select an existing one. You can also run this action on an entire organization.
 
 2. Choose an Example Workflow
-   Select the best-fit workflow file from the [examples](https://github.com/github/contributors/blob/main/README.md#example-workflow) provided and customize it to your needs with the ["Configuration" section of the contributors action README.md file](https://github.com/github/contributors/blob/main/README.md#configuration).
+   Select the best-fit workflow file from the [examples](https://github.com/github-community-projects/contributors/blob/main/README.md#example-workflow) provided and customize it to your needs with the ["Configuration" section of the contributors action README.md file](https://github.com/github-community-projects/contributors/blob/main/README.md#configuration).
 
 3. Copy and Edit the Workflow
    Copy the chosen example workflow into your repository and save it in the .github/workflows/ directory with the .yml file extension. Edit the values in the workflow to match your specific needs, including the organization or repository you want to measure, start and end dates (if applicable), and other configurations.


### PR DESCRIPTION
## Summary

The `github/contributors` repo was transferred to `github-community-projects/contributors`. This PR updates all references across the repository to point to the new location and the latest version.

## Changes

- **`.github/workflows/contributors.yml`**: Updated `uses: github/contributors@v1` → `uses: github-community-projects/contributors@v2` and updated `github/contributors` in the `REPOSITORY` env var list
- **`README.md`**: Updated repo link from `github/contributors` to `github-community-projects/contributors`
- **`docs/contributor-insights.md`**: Updated documentation links pointing to the contributors action README