### PR TITLE
Update measure-innersource references to new org

### DIFF
--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -32,7 +32,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           START_DATE: ${{ env.START_DATE }}
           END_DATE: ${{ env.END_DATE }}
-          REPOSITORY: "github/go-spdx,github-community-projects/internal-contribution-forks,github/stale-repos,github/evergreen,github/issue-metrics,github/github-ospo,github/contributors,github/automatic-contrib-prs,github/cleanowners,github/measure-innersource"
+          REPOSITORY: "github/go-spdx,github-community-projects/internal-contribution-forks,github/stale-repos,github/evergreen,github/issue-metrics,github/github-ospo,github/contributors,github/automatic-contrib-prs,github/cleanowners,github-community-projects/measure-innersource"
           SPONSOR_INFO: "true"
           LINK_TO_PROFILE: "true"
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ In addition to the information in this repository, we've also released a number 
 - [github/cleanowners](https://github.com/github/cleanowners) - A GitHub Action to suggest removal of non-organization members from CODEOWNERS files
 - [github/empty-repos](https://github.com/github/empty-repos) - Identify and report an organization's repositories that are empty or only contain a README
 - [github/ospo-reusable-workflows](https://github.com/github/ospo-reusable-workflows) - Centralized Reusable GitHub Actions workflows used by the other Actions above (example: release (image and discussion), auto labelling, etc)
-- [github/measure-innersource](https://github.com/github/measure-innersource) - Helps organizations track and improve their InnerSource adoption by quantifying the collaboration between different teams and departments.
+- [github-community-projects/measure-innersource](https://github.com/github-community-projects/measure-innersource) - Helps organizations track and improve their InnerSource adoption by quantifying the collaboration between different teams and departments.
 
 ### GitHub Apps
 


### PR DESCRIPTION
The `measure-innersource` repository has been transferred from `github/measure-innersource` to `github-community-projects/measure-innersource`. This PR updates all references to point to the new location.