### PR TITLE
Update cleanowners references to new org

### DIFF
--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -32,7 +32,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           START_DATE: ${{ env.START_DATE }}
           END_DATE: ${{ env.END_DATE }}
-          REPOSITORY: "github/go-spdx,github-community-projects/internal-contribution-forks,github/stale-repos,github/evergreen,github/issue-metrics,github/github-ospo,github/contributors,github/automatic-contrib-prs,github/cleanowners,github/measure-innersource"
+          REPOSITORY: "github/go-spdx,github-community-projects/internal-contribution-forks,github/stale-repos,github/evergreen,github/issue-metrics,github/github-ospo,github/contributors,github/automatic-contrib-prs,github-community-projects/cleanowners,github/measure-innersource"
           SPONSOR_INFO: "true"
           LINK_TO_PROFILE: "true"
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ In addition to the information in this repository, we've also released a number 
 - [github/evergreen](https://github.com/github/evergreen) - Enable automated security updates and open a issue/PR in repos in an org that have dependency files but no dependabot.yaml file
 - [github/issue-metrics](https://github.com/github/issue-metrics) - Gather metrics on issues/prs/discussions such as time to first response, count of issues opened, closed, etc.
 - [github/stale-repos](https://github.com/github/stale-repos) - Identify and report on repositories with no activity for configurable amount of time, in order to surface inactive repos to be considered for archival
-- [github/cleanowners](https://github.com/github/cleanowners) - A GitHub Action to suggest removal of non-organization members from CODEOWNERS files
+- [github-community-projects/cleanowners](https://github.com/github-community-projects/cleanowners) - A GitHub Action to suggest removal of non-organization members from CODEOWNERS files
 - [github/empty-repos](https://github.com/github/empty-repos) - Identify and report an organization's repositories that are empty or only contain a README
 - [github/ospo-reusable-workflows](https://github.com/github/ospo-reusable-workflows) - Centralized Reusable GitHub Actions workflows used by the other Actions above (example: release (image and discussion), auto labelling, etc)
 - [github/measure-innersource](https://github.com/github/measure-innersource) - Helps organizations track and improve their InnerSource adoption by quantifying the collaboration between different teams and departments.

--- a/docs/keeping-ownership-updated.md
+++ b/docs/keeping-ownership-updated.md
@@ -1,6 +1,6 @@
 # Keeping repository maintainer information accurate
 
-Companies and their structures are always evolving. Sometimes it feels like every Tuesday there is another reorganization going on. In that environment, it's easy for maintainership/ownership information about a repository to become outdated or unclear. Maintainers play a crucial role in guiding and stewarding a project, and knowing who they are is essential for efficient collaboration and decision-making. This information can be stored in the [`CODEOWNERS` file](https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) but how can we ensure that it’s up to date? Let's delve into why this matters and how the GitHub OSPO's tool, [`cleanowners`](https://github.com/github/cleanowners), can help maintainers achieve accurate ownership information for their projects.
+Companies and their structures are always evolving. Sometimes it feels like every Tuesday there is another reorganization going on. In that environment, it's easy for maintainership/ownership information about a repository to become outdated or unclear. Maintainers play a crucial role in guiding and stewarding a project, and knowing who they are is essential for efficient collaboration and decision-making. This information can be stored in the [`CODEOWNERS` file](https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) but how can we ensure that it’s up to date? Let's delve into why this matters and how the GitHub OSPO's tool, [`cleanowners`](https://github.com/github-community-projects/cleanowners), can help maintainers achieve accurate ownership information for their projects.
 
 ## The Importance of Accurate Maintainer Information
 
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Run cleanowners action
-        uses: github/cleanowners@v1
+        uses: github-community-projects/cleanowners@v1
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           ORGANIZATION: <YOUR_ORGANIZATION_GOES_HERE>
@@ -46,4 +46,4 @@ This workflow, triggered by scheduled runs, ensures that the CODEOWNERS file is 
 
 ## Dive in
 
-With tools like `cleanowners`, the task of managing CODEOWNERS files becomes actively managed instead of ignored, allowing maintainers to focus on what matters most: building and nurturing thriving software projects. By embracing clear and accurate ownership documentation practices, software projects can continue to flourish, guided by clear ownership and collaboration principles. Check out [the repository](https://github.com/github/cleanowners) for more information on how to configure and set up the action.
+With tools like `cleanowners`, the task of managing CODEOWNERS files becomes actively managed instead of ignored, allowing maintainers to focus on what matters most: building and nurturing thriving software projects. By embracing clear and accurate ownership documentation practices, software projects can continue to flourish, guided by clear ownership and collaboration principles. Check out [the repository](https://github.com/github-community-projects/cleanowners) for more information on how to configure and set up the action.


### PR DESCRIPTION
The `cleanowners` repository has been transferred from `github/cleanowners` to `github-community-projects/cleanowners`. This PR updates all references to point to the new location.