### PR TITLE
build: update references for all transferred repos to github-community-projects

### DIFF
--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -27,12 +27,12 @@ jobs:
           echo "END_DATE=$end_date" >> "$GITHUB_ENV"
 
       - name: Run contributor action
-        uses: github/contributors@v1
+        uses: github-community-projects/contributors@v2
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           START_DATE: ${{ env.START_DATE }}
           END_DATE: ${{ env.END_DATE }}
-          REPOSITORY: "github/go-spdx,github-community-projects/internal-contribution-forks,github/stale-repos,github/evergreen,github/issue-metrics,github/github-ospo,github/contributors,github/automatic-contrib-prs,github/cleanowners,github/measure-innersource"
+          REPOSITORY: "github/go-spdx,github-community-projects/internal-contribution-forks,github-community-projects/stale-repos,github-community-projects/evergreen,github-community-projects/issue-metrics,github/github-ospo,github-community-projects/contributors,github/automatic-contrib-prs,github-community-projects/cleanowners,github-community-projects/measure-innersource"
           SPONSOR_INFO: "true"
           LINK_TO_PROFILE: "true"
 

--- a/README.md
+++ b/README.md
@@ -43,14 +43,14 @@ We have used those as placeholder values where our policies point to internal on
 
 In addition to the information in this repository, we've also released a number of GitHub Actions that can help OSPOs track activity, clean house, and automate other useful activities. The actions are released in separate repos but are all linked here for convenience.
 
-- [github/contributors](https://github.com/github/contributors) - Given an organization or repository, produces information about the contributors over the specified time period.
-- [github/evergreen](https://github.com/github/evergreen) - Enable automated security updates and open a issue/PR in repos in an org that have dependency files but no dependabot.yaml file
-- [github/issue-metrics](https://github.com/github/issue-metrics) - Gather metrics on issues/prs/discussions such as time to first response, count of issues opened, closed, etc.
-- [github/stale-repos](https://github.com/github/stale-repos) - Identify and report on repositories with no activity for configurable amount of time, in order to surface inactive repos to be considered for archival
-- [github/cleanowners](https://github.com/github/cleanowners) - A GitHub Action to suggest removal of non-organization members from CODEOWNERS files
+- [github-community-projects/contributors](https://github.com/github-community-projects/contributors) - Given an organization or repository, produces information about the contributors over the specified time period.
+- [github-community-projects/evergreen](https://github.com/github-community-projects/evergreen) - Enable automated security updates and open a issue/PR in repos in an org that have dependency files but no dependabot.yaml file
+- [github-community-projects/issue-metrics](https://github.com/github-community-projects/issue-metrics) - Gather metrics on issues/prs/discussions such as time to first response, count of issues opened, closed, etc.
+- [github-community-projects/stale-repos](https://github.com/github-community-projects/stale-repos) - Identify and report on repositories with no activity for configurable amount of time, in order to surface inactive repos to be considered for archival
+- [github-community-projects/cleanowners](https://github.com/github-community-projects/cleanowners) - A GitHub Action to suggest removal of non-organization members from CODEOWNERS files
 - [github/empty-repos](https://github.com/github/empty-repos) - Identify and report an organization's repositories that are empty or only contain a README
 - [github/ospo-reusable-workflows](https://github.com/github/ospo-reusable-workflows) - Centralized Reusable GitHub Actions workflows used by the other Actions above (example: release (image and discussion), auto labelling, etc)
-- [github/measure-innersource](https://github.com/github/measure-innersource) - Helps organizations track and improve their InnerSource adoption by quantifying the collaboration between different teams and departments.
+- [github-community-projects/measure-innersource](https://github.com/github-community-projects/measure-innersource) - Helps organizations track and improve their InnerSource adoption by quantifying the collaboration between different teams and departments.
 
 ### GitHub Apps
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ We have used those as placeholder values where our policies point to internal on
 In addition to the information in this repository, we've also released a number of GitHub Actions that can help OSPOs track activity, clean house, and automate other useful activities. The actions are released in separate repos but are all linked here for convenience.
 
 - [github-community-projects/contributors](https://github.com/github-community-projects/contributors) - Given an organization or repository, produces information about the contributors over the specified time period.
-- [github-community-projects/evergreen](https://github.com/github-community-projects/evergreen) - Enable automated security updates and open a issue/PR in repos in an org that have dependency files but no dependabot.yaml file
+- [github-community-projects/evergreen](https://github.com/github-community-projects/evergreen) - Enable automated security updates and open an issue/PR in repos in an org that have dependency files but no dependabot.yaml file
 - [github-community-projects/issue-metrics](https://github.com/github-community-projects/issue-metrics) - Gather metrics on issues/prs/discussions such as time to first response, count of issues opened, closed, etc.
 - [github-community-projects/stale-repos](https://github.com/github-community-projects/stale-repos) - Identify and report on repositories with no activity for configurable amount of time, in order to surface inactive repos to be considered for archival
 - [github-community-projects/cleanowners](https://github.com/github-community-projects/cleanowners) - A GitHub Action to suggest removal of non-organization members from CODEOWNERS files

--- a/docs/contributor-insights.md
+++ b/docs/contributor-insights.md
@@ -35,7 +35,7 @@ Interested in implementing the contributors action in your project or organizati
    Start by creating a new repository to host the contributors GitHub action or select an existing one. You can also run this action on an entire organization.
 
 2. Choose an Example Workflow
-   Select the best-fit workflow file from the [examples](https://github.com/github/contributors/blob/main/README.md#example-workflow) provided and customize it to your needs with the ["Configuration" section of the contributors action README.md file](https://github.com/github/contributors/blob/main/README.md#configuration).
+   Select the best-fit workflow file from the [examples](https://github.com/github-community-projects/contributors/blob/main/README.md#example-workflow) provided and customize it to your needs with the ["Configuration" section of the contributors action README.md file](https://github.com/github-community-projects/contributors/blob/main/README.md#configuration).
 
 3. Copy and Edit the Workflow
    Copy the chosen example workflow into your repository and save it in the .github/workflows/ directory with the .yml file extension. Edit the values in the workflow to match your specific needs, including the organization or repository you want to measure, start and end dates (if applicable), and other configurations.

--- a/docs/issue-metrics.md
+++ b/docs/issue-metrics.md
@@ -6,7 +6,7 @@
 
 At GitHub, we believe that data-driven insights are the keys to success for any software development project. Understanding the health and progress of your issues, pull requests, and discussions is crucial for effective collaboration, maintainership, and project management.
 
-That is why we’re excited to announce the release of the [Issue Metrics GitHub Action](https://github.com/github/issue-metrics), a powerful tool that empowers developers and teams to measure key metrics and gain valuable insights into their projects.
+That is why we’re excited to announce the release of the [Issue Metrics GitHub Action](https://github.com/github-community-projects/issue-metrics), a powerful tool that empowers developers and teams to measure key metrics and gain valuable insights into their projects.
 
 With the new Issue Metrics GitHub Action, you can now easily track and monitor important metrics related to issues, pull requests, and discussions, such as **time to first response**, **time to close**, and more for any given time period.
 
@@ -40,7 +40,7 @@ Product development teams rely heavily on the code review process to collaborate
 
 Setting up the Issue Metrics GitHub Action takes a few minutes, compared to the few hours it takes to calculate these metrics manually. You also only need to set up the action once, and it will run on a regular basis of your own choosing. It integrates into your existing GitHub Actions workflow or you can create a new workflow specifically for metrics tracking.
 
-The action provides a wide range of customizable options, allowing you to tailor the issues, pull requests, and discussions measured by utilizing [GitHub’s powerful search filtering](https://docs.github.com/en/issues/tracking-your-work-with-issues/filtering-and-searching-issues-and-pull-requests). [Ready to use configurations](https://github.com/github/issue-metrics#example-workflows) have been tested and used internally at GitHub and are now available for you to try out as well.
+The action provides a wide range of customizable options, allowing you to tailor the issues, pull requests, and discussions measured by utilizing [GitHub’s powerful search filtering](https://docs.github.com/en/issues/tracking-your-work-with-issues/filtering-and-searching-issues-and-pull-requests). [Ready to use configurations](https://github.com/github-community-projects/issue-metrics#example-workflows) have been tested and used internally at GitHub and are now available for you to try out as well.
 
 Here is one such example that runs monthly to report on metrics for issues created last month:
 
@@ -80,7 +80,7 @@ jobs:
           echo "last_month=$first_day..$last_day" >> "$GITHUB_ENV"
 
       - name: Run issue-metrics tool
-        uses: github/issue-metrics@v2
+        uses: github-community-projects/issue-metrics@v4
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           SEARCH_QUERY: 'repo:owner/repo is:issue created:${{ env.last_month }} -reason:"not planned"'
@@ -95,6 +95,6 @@ jobs:
 
 ## Ready to start leveling up your GitHub project management?
 
-Head over to the [Issue Metrics GitHub Action repository](https://github.com/github/issue-metrics) to explore the documentation, installation instructions, and examples. The repository provides a comprehensive README file that guides you through the setup process and showcases the wide range of metrics you can measure. If you need additional help, feel free to open an issue in the repository.
+Head over to the [Issue Metrics GitHub Action repository](https://github.com/github-community-projects/issue-metrics) to explore the documentation, installation instructions, and examples. The repository provides a comprehensive README file that guides you through the setup process and showcases the wide range of metrics you can measure. If you need additional help, feel free to open an issue in the repository.
 
 GitHub is committed to providing developers with the best tools to enhance collaboration and productivity. The Issue Metrics GitHub Action is a significant step towards empowering teams to measure key metrics related to issues, pull requests, and discussions. By gaining valuable insights into the pulse of your projects, you can drive continuous improvement and deliver exceptional software. We are using this in several places internally across GitHub to help us continually improve and hope this action can help you as well. Happy coding!

--- a/docs/keeping-ownership-updated.md
+++ b/docs/keeping-ownership-updated.md
@@ -1,6 +1,6 @@
 # Keeping repository maintainer information accurate
 
-Companies and their structures are always evolving. Sometimes it feels like every Tuesday there is another reorganization going on. In that environment, it's easy for maintainership/ownership information about a repository to become outdated or unclear. Maintainers play a crucial role in guiding and stewarding a project, and knowing who they are is essential for efficient collaboration and decision-making. This information can be stored in the [`CODEOWNERS` file](https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) but how can we ensure that it’s up to date? Let's delve into why this matters and how the GitHub OSPO's tool, [`cleanowners`](https://github.com/github/cleanowners), can help maintainers achieve accurate ownership information for their projects.
+Companies and their structures are always evolving. Sometimes it feels like every Tuesday there is another reorganization going on. In that environment, it's easy for maintainership/ownership information about a repository to become outdated or unclear. Maintainers play a crucial role in guiding and stewarding a project, and knowing who they are is essential for efficient collaboration and decision-making. This information can be stored in the [`CODEOWNERS` file](https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) but how can we ensure that it’s up to date? Let's delve into why this matters and how the GitHub OSPO's tool, [`cleanowners`](https://github.com/github-community-projects/cleanowners), can help maintainers achieve accurate ownership information for their projects.
 
 ## The Importance of Accurate Maintainer Information
 
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Run cleanowners action
-        uses: github/cleanowners@v1
+        uses: github-community-projects/cleanowners@v1
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           ORGANIZATION: <YOUR_ORGANIZATION_GOES_HERE>
@@ -46,4 +46,4 @@ This workflow, triggered by scheduled runs, ensures that the CODEOWNERS file is 
 
 ## Dive in
 
-With tools like `cleanowners`, the task of managing CODEOWNERS files becomes actively managed instead of ignored, allowing maintainers to focus on what matters most: building and nurturing thriving software projects. By embracing clear and accurate ownership documentation practices, software projects can continue to flourish, guided by clear ownership and collaboration principles. Check out [the repository](https://github.com/github/cleanowners) for more information on how to configure and set up the action.
+With tools like `cleanowners`, the task of managing CODEOWNERS files becomes actively managed instead of ignored, allowing maintainers to focus on what matters most: building and nurturing thriving software projects. By embracing clear and accurate ownership documentation practices, software projects can continue to flourish, guided by clear ownership and collaboration principles. Check out [the repository](https://github.com/github-community-projects/cleanowners) for more information on how to configure and set up the action.

--- a/docs/managing-dependencies-at-scale.md
+++ b/docs/managing-dependencies-at-scale.md
@@ -2,7 +2,7 @@
 
 ![Swirling design graphic](https://github.blog/wp-content/uploads/2023/12/Productivity-LightMode-2.png?resize=1200%2C630)
 
-Keeping your repositories' dependencies up to date is crucial for maintaining quality and security. Outdated dependencies can expose your project to vulnerabilities, compromise its stability, and hinder its overall performance. In order to answer this question for ourselves, we created a [GitHub Action: Evergreen](https://github.com/github/evergreen).
+Keeping your repositories' dependencies up to date is crucial for maintaining quality and security. Outdated dependencies can expose your project to vulnerabilities, compromise its stability, and hinder its overall performance. In order to answer this question for ourselves, we created a [GitHub Action: Evergreen](https://github.com/github-community-projects/evergreen).
 
 ## The challenge of dependency management
 
@@ -18,7 +18,7 @@ While Dependabot version updates automates the task of updating dependencies, it
 
 ## Introducing Evergreen
 
-Inside GitHub, our Open Source Program Office (OSPO) wanted to make it easy to deploy Dependabot version updates throughout our own organizations. To achieve this, we built a GitHub Action called [Evergreen](https://github.com/github/evergreen). Evergreen acts as a dependency management assistant for your teams, ensuring that Dependabot version updates are enabled and configured consistently across all your repositories.
+Inside GitHub, our Open Source Program Office (OSPO) wanted to make it easy to deploy Dependabot version updates throughout our own organizations. To achieve this, we built a GitHub Action called [Evergreen](https://github.com/github-community-projects/evergreen). Evergreen acts as a dependency management assistant for your teams, ensuring that Dependabot version updates are enabled and configured consistently across all your repositories.
 
 [Small aside]With Evergreen, GitHub identified hundreds of our own private repositories to enable Dependabot on, and we'll continue to run updates so we can confidently keep our repositories up to date.[Small aside]
 
@@ -34,4 +34,4 @@ Once the GitHub Action triggers, it checks whether Dependabot version updates is
 
 ## Conclusion
 
-Keeping dependencies up to date is a non-negotiable aspect of ensuring the quality and security of your projects. Dependabot has made this task significantly easier, but it's also equally as important to ensure consistent implementation across all repositories. Evergreen automates the process of enabling and configuring it for every repository. Ensure your dependencies are evergreen! Check out [the repository](https://github.com/github/evergreen) for more information.
+Keeping dependencies up to date is a non-negotiable aspect of ensuring the quality and security of your projects. Dependabot has made this task significantly easier, but it's also equally as important to ensure consistent implementation across all repositories. Evergreen automates the process of enabling and configuring it for every repository. Ensure your dependencies are evergreen! Check out [the repository](https://github.com/github-community-projects/evergreen) for more information.


### PR DESCRIPTION
## Summary

The following repositories have been transferred from the `github` org to the `github-community-projects` org:

- **contributors**
- **evergreen**
- **issue-metrics**
- **stale-repos**
- **cleanowners**
- **measure-innersource**

This PR updates all references across the repository to point to the new locations.

## Changes

### `.github/workflows/contributors.yml`
- Updated `uses: github/contributors@v1` → `github-community-projects/contributors@v2`
- Updated all 6 transferred repos in the `REPOSITORY` env var list

### `README.md`
- Updated all 6 action links to the new org

### `docs/contributor-insights.md`
- Updated 2 links to the contributors action README

### `docs/issue-metrics.md`
- Updated 4 links to the issue-metrics repo
- Updated `uses: github/issue-metrics@v2` → `github-community-projects/issue-metrics@v4`

### `docs/keeping-ownership-updated.md`
- Updated 3 references to the cleanowners repo/action

### `docs/managing-dependencies-at-scale.md`
- Updated 3 references to the evergreen repo/action

## Consolidation

This PR supersedes and consolidates the following individual PRs:
- #190 (contributors)
- #191 (measure-innersource)
- #192 (cleanowners)
- #193 (stale-repos)

It also adds the previously missing updates for **evergreen** and **issue-metrics**.