### PR TITLE
chore: update ospo-reusable-workflows org path

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ In addition to the information in this repository, we've also released a number 
 - [github-community-projects/stale-repos](https://github.com/github-community-projects/stale-repos) - Identify and report on repositories with no activity for configurable amount of time, in order to surface inactive repos to be considered for archival
 - [github-community-projects/cleanowners](https://github.com/github-community-projects/cleanowners) - A GitHub Action to suggest removal of non-organization members from CODEOWNERS files
 - [github/empty-repos](https://github.com/github/empty-repos) - Identify and report an organization's repositories that are empty or only contain a README
-- [github/ospo-reusable-workflows](https://github.com/github/ospo-reusable-workflows) - Centralized Reusable GitHub Actions workflows used by the other Actions above (example: release (image and discussion), auto labelling, etc)
+- [github-community-projects/ospo-reusable-workflows](https://github.com/github-community-projects/ospo-reusable-workflows) - Centralized Reusable GitHub Actions workflows used by the other Actions above (example: release (image and discussion), auto labelling, etc)
 - [github-community-projects/measure-innersource](https://github.com/github-community-projects/measure-innersource) - Helps organizations track and improve their InnerSource adoption by quantifying the collaboration between different teams and departments.
 
 ### GitHub Apps


### PR DESCRIPTION
## What

Updated the path of the ospo-reusable-workflow repo to the github-community-projects org

## Why

The ospo-reusable-workflows repository was transferred to the `github-community-projects` organization, so the old path will stop resolving.

## Notes

- None